### PR TITLE
✨ Feat: 드래그앤드롭 순서 수정 UX를 위한 루트 스팟 재정렬 API 응답 개선

### DIFF
--- a/docs/api-specs/routes.md
+++ b/docs/api-specs/routes.md
@@ -309,14 +309,11 @@
 ```json
 {
   "statusCode": 200,
-  "data": {
-    "reordered": true,
-    "spots": [
-      { "routeSpotId": 10, "spotName": "남산서울타워", "sequenceOrder": 1 },
-      { "routeSpotId": 15, "spotName": "경복궁",       "sequenceOrder": 2 },
-      { "routeSpotId": 12, "spotName": "한강공원",     "sequenceOrder": 3 }
-    ]
-  },
+  "data": [
+    { "routeSpotId": 10, "spotId": 101, "sequenceOrder": 1 },
+    { "routeSpotId": 15, "spotId": 105, "sequenceOrder": 2 },
+    { "routeSpotId": 12, "spotId": 103, "sequenceOrder": 3 }
+  ],
   "error": null
 }
 ```

--- a/src/main/java/com/Wavey/WaveyService/domain/route/controller/RouteSpotController.java
+++ b/src/main/java/com/Wavey/WaveyService/domain/route/controller/RouteSpotController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -58,14 +59,14 @@ public class RouteSpotController {
             @ApiResponse(responseCode = "404", description = "루트를 찾을 수 없음")
     })
     @PatchMapping("/reorder")
-    public ResponseEntity<CommonResponse<Void>> reorderSpots(
+    public ResponseEntity<CommonResponse<List<RouteSpotResponse>>> reorderSpots(
             @Parameter(hidden = true) @AuthenticationPrincipal UserDetails userDetails,
             @Parameter(description = "루트 ID") @PathVariable Long routeId,
             @RequestBody @Valid RouteSpotReorderRequest request
     ) {
         Long userId = extractUserId(userDetails);
-        routeSpotService.reorderSpots(routeId, request, userId);
-        return ResponseEntity.ok(CommonResponse.success("스팟 순서 변경 성공", null));
+        List<RouteSpotResponse> response = routeSpotService.reorderSpots(routeId, request, userId);
+        return ResponseEntity.ok(CommonResponse.success("스팟 순서 변경 성공", response));
     }
 
     @Operation(summary = "루트에서 스팟 제거", description = "루트에서 특정 스팟을 제거합니다. 스팟 자체는 삭제되지 않습니다.")

--- a/src/main/java/com/Wavey/WaveyService/domain/route/service/RouteSpotService.java
+++ b/src/main/java/com/Wavey/WaveyService/domain/route/service/RouteSpotService.java
@@ -42,7 +42,7 @@ public class RouteSpotService {
     }
 
     @Transactional
-    public void reorderSpots(Long routeId, RouteSpotReorderRequest request, Long userId) {
+    public List<RouteSpotResponse> reorderSpots(Long routeId, RouteSpotReorderRequest request, Long userId) {
         Route route = routeService.findRouteById(routeId);
         routeService.validateOwner(route, userId);
 
@@ -62,6 +62,10 @@ public class RouteSpotService {
             }
             routeSpot.updateSequence(item.getSequenceOrder());
         });
+
+        return routeSpotRepository.findByRouteIdOrderBySequenceOrderAsc(routeId).stream()
+                .map(RouteSpotResponse::from)
+                .toList();
     }
 
     @Transactional

--- a/src/test/java/com/Wavey/WaveyService/domain/route/service/RouteSpotServiceTest.java
+++ b/src/test/java/com/Wavey/WaveyService/domain/route/service/RouteSpotServiceTest.java
@@ -1,0 +1,128 @@
+package com.Wavey.WaveyService.domain.route.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.mockito.Mockito.verify;
+
+import com.Wavey.WaveyService.domain.route.dto.request.RouteSpotOrderItem;
+import com.Wavey.WaveyService.domain.route.dto.request.RouteSpotReorderRequest;
+import com.Wavey.WaveyService.domain.route.dto.response.RouteSpotResponse;
+import com.Wavey.WaveyService.domain.route.entity.Route;
+import com.Wavey.WaveyService.domain.route.entity.RouteSpot;
+import com.Wavey.WaveyService.domain.route.repository.RouteSpotRepository;
+import com.Wavey.WaveyService.global.exception.CustomException;
+import com.Wavey.WaveyService.global.exception.ErrorCode;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class RouteSpotServiceTest {
+
+    @Mock
+    private RouteSpotRepository routeSpotRepository;
+
+    @Mock
+    private RouteService routeService;
+
+    @InjectMocks
+    private RouteSpotService routeSpotService;
+
+    private final Long routeId = 1L;
+    private final Long ownerId = 100L;
+    private Route route;
+
+    @BeforeEach
+    void setUp() {
+        route = Route.builder().userId(ownerId).build();
+        ReflectionTestUtils.setField(route, "id", routeId);
+    }
+
+    private RouteSpot routeSpot(Long id, Long spotId, int sequenceOrder) {
+        RouteSpot routeSpot = RouteSpot.builder()
+                .route(route)
+                .spotId(spotId)
+                .sequenceOrder(sequenceOrder)
+                .build();
+        ReflectionTestUtils.setField(routeSpot, "id", id);
+        return routeSpot;
+    }
+
+    @Test
+    void 재정렬_성공시_최신_순서로_정렬된_스팟_목록을_반환한다() {
+        List<RouteSpot> currentSpots = List.of(
+                routeSpot(10L, 101L, 1),
+                routeSpot(11L, 102L, 2)
+        );
+        List<RouteSpot> reorderedSpots = List.of(
+                routeSpot(11L, 102L, 1),
+                routeSpot(10L, 101L, 2)
+        );
+        RouteSpotReorderRequest request = new RouteSpotReorderRequest(List.of(
+                new RouteSpotOrderItem(11L, 1),
+                new RouteSpotOrderItem(10L, 2)
+        ));
+
+        given(routeService.findRouteById(routeId)).willReturn(route);
+        given(routeSpotRepository.findByRouteIdOrderBySequenceOrderAsc(routeId))
+                .willReturn(currentSpots, reorderedSpots);
+
+        List<RouteSpotResponse> result = routeSpotService.reorderSpots(routeId, request, ownerId);
+
+        assertThat(result).extracting(RouteSpotResponse::getRouteSpotId)
+                .containsExactly(11L, 10L);
+        verify(routeService).validateOwner(route, ownerId);
+    }
+
+    @Test
+    void 요청된_스팟_개수가_실제_개수와_다르면_예외가_발생한다() {
+        List<RouteSpot> currentSpots = List.of(routeSpot(10L, 101L, 1), routeSpot(11L, 102L, 2));
+        RouteSpotReorderRequest request = new RouteSpotReorderRequest(List.of(
+                new RouteSpotOrderItem(10L, 1)
+        ));
+
+        given(routeService.findRouteById(routeId)).willReturn(route);
+        given(routeSpotRepository.findByRouteIdOrderBySequenceOrderAsc(routeId)).willReturn(currentSpots);
+
+        assertThatThrownBy(() -> routeSpotService.reorderSpots(routeId, request, ownerId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROUTE_SPOT_ORDER_MISMATCH);
+    }
+
+    @Test
+    void 존재하지_않는_라우트_스팟_ID가_포함되면_예외가_발생한다() {
+        List<RouteSpot> currentSpots = List.of(routeSpot(10L, 101L, 1));
+        RouteSpotReorderRequest request = new RouteSpotReorderRequest(List.of(
+                new RouteSpotOrderItem(999L, 1)
+        ));
+
+        given(routeService.findRouteById(routeId)).willReturn(route);
+        given(routeSpotRepository.findByRouteIdOrderBySequenceOrderAsc(routeId)).willReturn(currentSpots);
+
+        assertThatThrownBy(() -> routeSpotService.reorderSpots(routeId, request, ownerId))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROUTE_SPOT_NOT_FOUND);
+    }
+
+    @Test
+    void 소유자가_아니면_예외가_발생한다() {
+        RouteSpotReorderRequest request = new RouteSpotReorderRequest(List.of(
+                new RouteSpotOrderItem(10L, 1)
+        ));
+
+        given(routeService.findRouteById(routeId)).willReturn(route);
+        willThrow(new CustomException(ErrorCode.ROUTE_FORBIDDEN))
+                .given(routeService).validateOwner(route, 999L);
+
+        assertThatThrownBy(() -> routeSpotService.reorderSpots(routeId, request, 999L))
+                .isInstanceOf(CustomException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.ROUTE_FORBIDDEN);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈
- #23

## 📝 작업 내용

### ✨ Feat
| 내용 | 파일 |
|------|------|
| 스팟 재정렬 시 최신 순서 목록을 반환하도록 서비스 로직 변경 | `RouteSpotService.java` |
| reorder 엔드포인트 응답 타입을 `Void` → `List<RouteSpotResponse>`로 변경 | `RouteSpotController.java` |

### 📚 Docs
| 내용 | 파일 |
|------|------|
| 스팟 재정렬 API 응답 명세 최신화 | `docs/api-specs/routes.md` |

### 🧪 Test
| 내용 | 파일 |
|------|------|
| 스팟 재정렬 서비스 단위 테스트 추가 (성공/개수 불일치/미존재 스팟/권한 없음) | `RouteSpotServiceTest.java` |

## 📌 공유 사항
> 1. `GET /api/v1/routes/{routeId}`가 이미 `sequenceOrder` 순 정렬된 `spots`를 반환하고 있어, 별도의 스팟 목록 조회 API는 추가하지 않았습니다.
> 2. reorder 시 요청 스팟 개수와 전체 개수가 일치해야 하는 기존 정책은 그대로 유지했습니다. (드래그앤드롭은 드롭 시점에 전체 순서 배열을 한 번에 재전송하는 방식이라 부분 업데이트가 필요하지 않다고 판단)
> 3. 테스트 중 `ContentService.java`에서 기존에 존재하던 컴파일 에러(`getCreated_at`/`getUpdated_at` 미존재 메서드)를 발견했습니다. 본 PR과 무관한 영역이라 별도로 손대지 않았으니 확인 부탁드립니다.

## ✅ 체크리스트
- [x] Reviewer에 팀원들을 선택했나요?
- [x] Assignees에 본인을 선택했나요?
- [x] 컨벤션에 맞는 Type을 선택했나요?
- [x] Development에 이슈를 연동했나요?
- [x] Merge 하려는 브랜치가 올바르게 설정되어 있나요?
- [x] 컨벤션을 지키고 있나요?
- [x] 로컬에서 실행했을 때 에러가 발생하지 않나요?
- [x] 팀원들에게 PR 링크 공유를 했나요?

## 💬 리뷰 요구사항
> 1. reorder 응답을 `List<RouteSpotResponse>`로 바꾼 방향이 프론트 드래그앤드롭 동기화 목적에 적합한지 의견 부탁드립니다.